### PR TITLE
Require Kernel context for Vault.Rotation timer work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Timer-triggered rotation executions now establish Kernel Grid/Operation context with internal tenant context before invoking rotators.
 - Rotation context correlation IDs are required and non-empty.
 - Placeholder provider rotators now share a reusable scaffold while preserving provider-specific names and skipped messages.
+- Runtime/test dependencies refreshed for current Kernel/Vault alignment validation.
 - Unit and canary project stubs.
 - GitHub Actions workflows for PR validation, release artifact publication, and staging deployment.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 - Initial HoneyDrunk.Vault.Rotation Function App scaffold for ADR-0006 Tier 2 third-party secret rotation.
 - Public rotation contracts in HoneyDrunk.Vault.Rotation.Abstractions.
 - Provider discovery scaffolding and Resend, Twilio, and OpenAI rotator stubs.
+- Timer-triggered rotation executions now establish Kernel Grid/Operation context with internal tenant context before invoking rotators.
+- Rotation context correlation IDs are required and non-empty.
+- Placeholder provider rotators now share a reusable scaffold while preserving provider-specific names and skipped messages.
 - Unit and canary project stubs.
 - GitHub Actions workflows for PR validation, release artifact publication, and staging deployment.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ HoneyDrunk.Vault.Rotation owns scheduled rotation orchestration for provider sec
 
 ## Grid Placement
 
-- **Node:** `honeydrunk-vault-rotation`
+- **Node:** `honeydrunk-vault-rotation` via `WellKnownNodes.Core.VaultRotation` unless `HONEYDRUNK_NODE_ID` / `Grid:NodeId` overrides it
 - **Service token:** `vaultrot`
 - **Tier:** ADR-0006 Tier 2, third-party rotation within 90 days
 - **Vault:** `kv-hd-vaultrot-{env}`
@@ -17,6 +17,8 @@ HoneyDrunk.Vault.Rotation owns scheduled rotation orchestration for provider sec
 
 - `vaultrot` is 8 characters, which satisfies the 13-character service-name budget from ADR-0005.
 - The Function App uses OIDC for CI deployment authentication. Service-principal client secrets are not used.
+- Every scheduled rotation execution establishes a Kernel Grid/Operation context before provider work begins.
+- Internal system rotation work uses Kernel internal tenant context by default.
 - Rotation code must write new secret versions and consumers must continue resolving latest versions through `ISecretStore`.
 - This Node does not duplicate Azure-native Key Vault rotation.
 

--- a/src/HoneyDrunk.Vault.Rotation.Abstractions/README.md
+++ b/src/HoneyDrunk.Vault.Rotation.Abstractions/README.md
@@ -1,3 +1,5 @@
 # HoneyDrunk.Vault.Rotation.Abstractions
 
 Contracts for third-party secret rotation in the HoneyDrunk Grid.
+
+`RotationContext.CorrelationId` is required and must be non-empty so every rotation attempt can be tied back to the Kernel operation context that scheduled it.

--- a/src/HoneyDrunk.Vault.Rotation.Abstractions/RotationContext.cs
+++ b/src/HoneyDrunk.Vault.Rotation.Abstractions/RotationContext.cs
@@ -3,16 +3,65 @@ namespace HoneyDrunk.Vault.Rotation.Abstractions;
 /// <summary>
 /// Describes a third-party secret rotation request.
 /// </summary>
-/// <param name="ProviderName">The provider to rotate.</param>
-/// <param name="TargetVaultName">The destination Key Vault name.</param>
-/// <param name="SecretName">The destination secret name.</param>
-/// <param name="RequestedAtUtc">The UTC time the rotation was requested.</param>
-/// <param name="CorrelationId">An optional cross-system correlation identifier.</param>
-/// <param name="Metadata">Additional provider-specific request metadata.</param>
-public sealed record RotationContext(
-    string ProviderName,
-    string TargetVaultName,
-    string SecretName,
-    DateTimeOffset RequestedAtUtc,
-    string? CorrelationId = null,
-    IReadOnlyDictionary<string, string>? Metadata = null);
+public sealed record RotationContext
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RotationContext"/> class.
+    /// </summary>
+    /// <param name="providerName">The provider to rotate.</param>
+    /// <param name="targetVaultName">The destination Key Vault name.</param>
+    /// <param name="secretName">The destination secret name.</param>
+    /// <param name="requestedAtUtc">The UTC time the rotation was requested.</param>
+    /// <param name="correlationId">A non-empty cross-system correlation identifier.</param>
+    /// <param name="metadata">Additional provider-specific request metadata.</param>
+    public RotationContext(
+        string providerName,
+        string targetVaultName,
+        string secretName,
+        DateTimeOffset requestedAtUtc,
+        string correlationId,
+        IReadOnlyDictionary<string, string>? metadata = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetVaultName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(secretName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
+
+        ProviderName = providerName;
+        TargetVaultName = targetVaultName;
+        SecretName = secretName;
+        RequestedAtUtc = requestedAtUtc;
+        CorrelationId = correlationId;
+        Metadata = metadata;
+    }
+
+    /// <summary>
+    /// Gets the provider to rotate.
+    /// </summary>
+    public string ProviderName { get; init; }
+
+    /// <summary>
+    /// Gets the destination Key Vault name.
+    /// </summary>
+    public string TargetVaultName { get; init; }
+
+    /// <summary>
+    /// Gets the destination secret name.
+    /// </summary>
+    public string SecretName { get; init; }
+
+    /// <summary>
+    /// Gets the UTC time the rotation was requested.
+    /// </summary>
+    public DateTimeOffset RequestedAtUtc { get; init; }
+
+    /// <summary>
+    /// Gets the non-empty cross-system correlation identifier.
+    /// </summary>
+    public string CorrelationId { get; init; }
+
+    /// <summary>
+    /// Gets additional provider-specific request metadata.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Metadata { get; init; }
+}

--- a/src/HoneyDrunk.Vault.Rotation.Abstractions/RotationContext.cs
+++ b/src/HoneyDrunk.Vault.Rotation.Abstractions/RotationContext.cs
@@ -5,6 +5,11 @@ namespace HoneyDrunk.Vault.Rotation.Abstractions;
 /// </summary>
 public sealed record RotationContext
 {
+    private string _providerName = string.Empty;
+    private string _targetVaultName = string.Empty;
+    private string _secretName = string.Empty;
+    private string _correlationId = string.Empty;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RotationContext"/> class.
     /// </summary>
@@ -22,11 +27,6 @@ public sealed record RotationContext
         string correlationId,
         IReadOnlyDictionary<string, string>? metadata = null)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(providerName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(targetVaultName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(secretName);
-        ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
-
         ProviderName = providerName;
         TargetVaultName = targetVaultName;
         SecretName = secretName;
@@ -38,17 +38,41 @@ public sealed record RotationContext
     /// <summary>
     /// Gets the provider to rotate.
     /// </summary>
-    public string ProviderName { get; init; }
+    public string ProviderName
+    {
+        get => _providerName;
+        init
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(value);
+            _providerName = value;
+        }
+    }
 
     /// <summary>
     /// Gets the destination Key Vault name.
     /// </summary>
-    public string TargetVaultName { get; init; }
+    public string TargetVaultName
+    {
+        get => _targetVaultName;
+        init
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(value);
+            _targetVaultName = value;
+        }
+    }
 
     /// <summary>
     /// Gets the destination secret name.
     /// </summary>
-    public string SecretName { get; init; }
+    public string SecretName
+    {
+        get => _secretName;
+        init
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(value);
+            _secretName = value;
+        }
+    }
 
     /// <summary>
     /// Gets the UTC time the rotation was requested.
@@ -58,7 +82,15 @@ public sealed record RotationContext
     /// <summary>
     /// Gets the non-empty cross-system correlation identifier.
     /// </summary>
-    public string CorrelationId { get; init; }
+    public string CorrelationId
+    {
+        get => _correlationId;
+        init
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(value);
+            _correlationId = value;
+        }
+    }
 
     /// <summary>
     /// Gets additional provider-specific request metadata.

--- a/src/HoneyDrunk.Vault.Rotation.Providers/HoneyDrunk.Vault.Rotation.Providers.csproj
+++ b/src/HoneyDrunk.Vault.Rotation.Providers/HoneyDrunk.Vault.Rotation.Providers.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.9.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.10.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HoneyDrunk.Vault.Rotation.Providers/OpenAI/OpenAIRotator.cs
+++ b/src/HoneyDrunk.Vault.Rotation.Providers/OpenAI/OpenAIRotator.cs
@@ -1,23 +1,6 @@
-using HoneyDrunk.Vault.Rotation.Abstractions;
-
 namespace HoneyDrunk.Vault.Rotation.Providers.OpenAI;
 
 /// <summary>
 /// Placeholder rotator for OpenAI API keys.
 /// </summary>
-public sealed class OpenAIRotator : IRotator
-{
-    /// <inheritdoc />
-    public string ProviderName => "openai";
-
-    /// <inheritdoc />
-    public Task<RotationResult> RotateAsync(RotationContext ctx, CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(ctx);
-        ct.ThrowIfCancellationRequested();
-
-        return Task.FromResult(RotationResult.Skipped(
-            ProviderName,
-            "OpenAI rotation is not implemented in the scaffold."));
-    }
-}
+public sealed class OpenAIRotator() : PlaceholderRotator("openai", "OpenAI");

--- a/src/HoneyDrunk.Vault.Rotation.Providers/PlaceholderRotator.cs
+++ b/src/HoneyDrunk.Vault.Rotation.Providers/PlaceholderRotator.cs
@@ -1,0 +1,35 @@
+using HoneyDrunk.Vault.Rotation.Abstractions;
+
+namespace HoneyDrunk.Vault.Rotation.Providers;
+
+/// <summary>
+/// Base scaffold for providers whose automatic rotation behavior has not landed yet.
+/// </summary>
+/// <remarks>
+/// This class intentionally returns <see cref="RotationStatus.Skipped"/> so provider registrations are observable
+/// without implying real third-party credential rotation.
+/// </remarks>
+/// <param name="providerName">The canonical provider name.</param>
+/// <param name="displayName">The human-readable provider name used in skipped messages.</param>
+public abstract class PlaceholderRotator(string providerName, string displayName) : IRotator
+{
+    private readonly string _displayName = string.IsNullOrWhiteSpace(displayName)
+        ? throw new ArgumentException("Display name cannot be null or whitespace.", nameof(displayName))
+        : displayName;
+
+    /// <inheritdoc />
+    public string ProviderName { get; } = string.IsNullOrWhiteSpace(providerName)
+        ? throw new ArgumentException("Provider name cannot be null or whitespace.", nameof(providerName))
+        : providerName;
+
+    /// <inheritdoc />
+    public Task<RotationResult> RotateAsync(RotationContext ctx, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+        ct.ThrowIfCancellationRequested();
+
+        return Task.FromResult(RotationResult.Skipped(
+            ProviderName,
+            $"{_displayName} rotation is not implemented in the scaffold."));
+    }
+}

--- a/src/HoneyDrunk.Vault.Rotation.Providers/README.md
+++ b/src/HoneyDrunk.Vault.Rotation.Providers/README.md
@@ -1,3 +1,5 @@
 # HoneyDrunk.Vault.Rotation.Providers
 
 Provider rotator discovery and placeholder rotators for Resend, Twilio, and OpenAI.
+
+The current provider rotators intentionally share the placeholder scaffold and return skipped results until real provider-specific rotation packets land.

--- a/src/HoneyDrunk.Vault.Rotation.Providers/Resend/ResendRotator.cs
+++ b/src/HoneyDrunk.Vault.Rotation.Providers/Resend/ResendRotator.cs
@@ -1,23 +1,6 @@
-using HoneyDrunk.Vault.Rotation.Abstractions;
-
 namespace HoneyDrunk.Vault.Rotation.Providers.Resend;
 
 /// <summary>
 /// Placeholder rotator for Resend API keys.
 /// </summary>
-public sealed class ResendRotator : IRotator
-{
-    /// <inheritdoc />
-    public string ProviderName => "resend";
-
-    /// <inheritdoc />
-    public Task<RotationResult> RotateAsync(RotationContext ctx, CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(ctx);
-        ct.ThrowIfCancellationRequested();
-
-        return Task.FromResult(RotationResult.Skipped(
-            ProviderName,
-            "Resend rotation is not implemented in the scaffold."));
-    }
-}
+public sealed class ResendRotator() : PlaceholderRotator("resend", "Resend");

--- a/src/HoneyDrunk.Vault.Rotation.Providers/Twilio/TwilioRotator.cs
+++ b/src/HoneyDrunk.Vault.Rotation.Providers/Twilio/TwilioRotator.cs
@@ -1,23 +1,6 @@
-using HoneyDrunk.Vault.Rotation.Abstractions;
-
 namespace HoneyDrunk.Vault.Rotation.Providers.Twilio;
 
 /// <summary>
 /// Placeholder rotator for Twilio credentials.
 /// </summary>
-public sealed class TwilioRotator : IRotator
-{
-    /// <inheritdoc />
-    public string ProviderName => "twilio";
-
-    /// <inheritdoc />
-    public Task<RotationResult> RotateAsync(RotationContext ctx, CancellationToken ct)
-    {
-        ArgumentNullException.ThrowIfNull(ctx);
-        ct.ThrowIfCancellationRequested();
-
-        return Task.FromResult(RotationResult.Skipped(
-            ProviderName,
-            "Twilio rotation is not implemented in the scaffold."));
-    }
-}
+public sealed class TwilioRotator() : PlaceholderRotator("twilio", "Twilio");

--- a/src/HoneyDrunk.Vault.Rotation/HoneyDrunk.Vault.Rotation.csproj
+++ b/src/HoneyDrunk.Vault.Rotation/HoneyDrunk.Vault.Rotation.csproj
@@ -13,11 +13,11 @@
     <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Vault" Version="0.5.0" />
     <PackageReference Include="HoneyDrunk.Vault.Providers.AzureKeyVault" Version="0.5.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HoneyDrunk.Vault.Rotation/HoneyDrunk.Vault.Rotation.csproj
+++ b/src/HoneyDrunk.Vault.Rotation/HoneyDrunk.Vault.Rotation.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="HoneyDrunk.Kernel" Version="0.4.0" />
-    <PackageReference Include="HoneyDrunk.Vault" Version="0.2.0" />
-    <PackageReference Include="HoneyDrunk.Vault.Providers.AzureKeyVault" Version="0.2.0" />
+    <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
+    <PackageReference Include="HoneyDrunk.Vault" Version="0.5.0" />
+    <PackageReference Include="HoneyDrunk.Vault.Providers.AzureKeyVault" Version="0.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />

--- a/src/HoneyDrunk.Vault.Rotation/Program.cs
+++ b/src/HoneyDrunk.Vault.Rotation/Program.cs
@@ -16,7 +16,7 @@ var builder = FunctionsApplication.CreateBuilder(args);
 var honeyDrunkBuilder = builder.Services
     .AddHoneyDrunkNode(options =>
     {
-        options.NodeId = new NodeId("honeydrunk-vault-rotation");
+        options.NodeId = ResolveNodeId(builder.Configuration);
         options.SectorId = Sectors.Core;
         options.EnvironmentId = ResolveEnvironment(builder.Configuration);
         options.Version = typeof(Program).Assembly.GetName().Version?.ToString() ?? "0.1.0";
@@ -39,6 +39,17 @@ honeyDrunkBuilder.Services
     .AddHoneyDrunkVaultRotators();
 
 builder.Build().Run();
+
+static NodeId ResolveNodeId(IConfiguration configuration)
+{
+    var configured =
+        configuration["HONEYDRUNK_NODE_ID"]
+        ?? configuration["Grid:NodeId"];
+
+    return string.IsNullOrWhiteSpace(configured)
+        ? WellKnownNodes.Core.VaultRotation
+        : new NodeId(configured);
+}
 
 static EnvironmentId ResolveEnvironment(IConfiguration configuration)
 {

--- a/src/HoneyDrunk.Vault.Rotation/RotateThirdPartySecretsFunction.cs
+++ b/src/HoneyDrunk.Vault.Rotation/RotateThirdPartySecretsFunction.cs
@@ -1,5 +1,9 @@
+using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Context;
+using HoneyDrunk.Kernel.Context.Mappers;
 using HoneyDrunk.Vault.Rotation.Abstractions;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace HoneyDrunk.Vault.Rotation;
@@ -8,9 +12,12 @@ namespace HoneyDrunk.Vault.Rotation;
 /// Scheduled entry point for third-party secret rotation.
 /// </summary>
 public sealed class RotateThirdPartySecretsFunction(
-    IEnumerable<IRotator> rotators,
+    IServiceScopeFactory serviceScopeFactory,
     ILogger<RotateThirdPartySecretsFunction> logger)
 {
+    private const string OperationName = "RotateThirdPartySecrets";
+    private const string PlaceholderTargetVaultName = "pending-target-vault";
+
     /// <summary>
     /// Runs the scheduled rotation placeholder.
     /// </summary>
@@ -18,16 +25,80 @@ public sealed class RotateThirdPartySecretsFunction(
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A completed task.</returns>
     [Function(nameof(RotateThirdPartySecretsFunction))]
-    public Task Run(
+    public async Task Run(
         [TimerTrigger("%RotationSchedule%")] TimerInfo timer,
         CancellationToken cancellationToken)
     {
+        _ = timer;
         cancellationToken.ThrowIfCancellationRequested();
 
-        logger.LogInformation(
-            "Third-party secret rotation is not yet implemented. Discovered {RotatorCount} rotator stubs.",
-            rotators.Count());
+        using var scope = serviceScopeFactory.CreateScope();
+        var services = scope.ServiceProvider;
+        var gridContext = services.GetRequiredService<GridContext>();
+        var operationContextFactory = services.GetRequiredService<IOperationContextFactory>();
+        var operationContextAccessor = services.GetRequiredService<IOperationContextAccessor>();
 
-        return Task.CompletedTask;
+        JobContextMapper.InitializeForScheduledJob(
+            gridContext,
+            OperationName,
+            DateTimeOffset.UtcNow,
+            cancellationToken);
+
+        using var operationContext = operationContextFactory.Create(
+            OperationName,
+            new Dictionary<string, object?>
+            {
+                ["trigger"] = "timer",
+            });
+
+        try
+        {
+            var rotators = services.GetServices<IRotator>().ToArray();
+
+            logger.LogInformation(
+                "Starting third-party secret rotation scaffold with {RotatorCount} rotator stubs and CorrelationId {CorrelationId}.",
+                rotators.Length,
+                operationContext.CorrelationId);
+
+            foreach (var rotator in rotators)
+            {
+                var context = CreateRotationContext(rotator.ProviderName, operationContext.CorrelationId);
+                var result = await rotator.RotateAsync(context, cancellationToken).ConfigureAwait(false);
+
+                logger.LogInformation(
+                    "Rotation provider {ProviderName} completed with status {RotationStatus} and CorrelationId {CorrelationId}.",
+                    result.ProviderName,
+                    result.Status,
+                    context.CorrelationId);
+            }
+
+            operationContext.Complete();
+        }
+        catch (OperationCanceledException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            operationContext.Fail("Third-party secret rotation scaffold was canceled.", ex);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            operationContext.Fail("Third-party secret rotation scaffold failed.", ex);
+            throw;
+        }
+        finally
+        {
+            operationContextAccessor.Current = null;
+        }
     }
+
+    private static RotationContext CreateRotationContext(string providerName, string correlationId) =>
+        new(
+            providerName,
+            PlaceholderTargetVaultName,
+            $"{providerName}-secret-placeholder",
+            DateTimeOffset.UtcNow,
+            correlationId,
+            new Dictionary<string, string>
+            {
+                ["rotation-mode"] = "placeholder",
+            });
 }

--- a/tests/HoneyDrunk.Vault.Rotation.Canary/HoneyDrunk.Vault.Rotation.Canary.csproj
+++ b/tests/HoneyDrunk.Vault.Rotation.Canary/HoneyDrunk.Vault.Rotation.Canary.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/HoneyDrunk.Vault.Rotation.Tests.csproj
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/HoneyDrunk.Vault.Rotation.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\HoneyDrunk.Vault.Rotation.Abstractions\HoneyDrunk.Vault.Rotation.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\HoneyDrunk.Vault.Rotation.Providers\HoneyDrunk.Vault.Rotation.Providers.csproj" />
+    <ProjectReference Include="..\..\src\HoneyDrunk.Vault.Rotation\HoneyDrunk.Vault.Rotation.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/HoneyDrunk.Vault.Rotation.Tests.csproj
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/HoneyDrunk.Vault.Rotation.Tests.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/RotateThirdPartySecretsFunctionTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/RotateThirdPartySecretsFunctionTests.cs
@@ -1,0 +1,93 @@
+using HoneyDrunk.Kernel.Abstractions;
+using HoneyDrunk.Kernel.Abstractions.Context;
+using HoneyDrunk.Kernel.Abstractions.Identity;
+using HoneyDrunk.Kernel.Hosting;
+using HoneyDrunk.Vault.Rotation.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using GridEnvironments = HoneyDrunk.Kernel.Abstractions.Environments;
+
+namespace HoneyDrunk.Vault.Rotation.Tests;
+
+/// <summary>
+/// Tests for the timer-triggered rotation function.
+/// </summary>
+public sealed class RotateThirdPartySecretsFunctionTests
+{
+    /// <summary>
+    /// Verifies that timer execution creates Kernel context before invoking rotators.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task RunCreatesKernelOperationContextForTimerExecution()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services
+            .AddHoneyDrunkNode(options =>
+            {
+                options.NodeId = WellKnownNodes.Core.VaultRotation;
+                options.SectorId = Sectors.Core;
+                options.EnvironmentId = GridEnvironments.Development;
+                options.StudioId = "honeydrunk";
+                options.Version = "0.1.0";
+            })
+            .Services
+            .AddSingleton<CapturingRotator>()
+            .AddSingleton<IRotator>(sp => sp.GetRequiredService<CapturingRotator>());
+
+        using var provider = services.BuildServiceProvider();
+        var function = new RotateThirdPartySecretsFunction(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<RotateThirdPartySecretsFunction>.Instance);
+
+        await function.Run(null!, CancellationToken.None);
+
+        var rotator = provider.GetRequiredService<CapturingRotator>();
+        Assert.NotNull(rotator.Context);
+        Assert.False(string.IsNullOrWhiteSpace(rotator.Context.CorrelationId));
+        Assert.Equal(TenantId.Internal, rotator.TenantId);
+        Assert.Equal(WellKnownNodes.Core.VaultRotation.Value, rotator.NodeId);
+        Assert.Null(provider.GetRequiredService<IOperationContextAccessor>().Current);
+    }
+
+    /// <summary>
+    /// Test rotator that captures the active rotation and Kernel operation context.
+    /// </summary>
+    /// <param name="operationContextAccessor">The operation context accessor.</param>
+    public sealed class CapturingRotator(IOperationContextAccessor operationContextAccessor) : IRotator
+    {
+        /// <summary>
+        /// Gets the captured rotation context.
+        /// </summary>
+        public RotationContext? Context { get; private set; }
+
+        /// <summary>
+        /// Gets the captured tenant identifier.
+        /// </summary>
+        public TenantId? TenantId { get; private set; }
+
+        /// <summary>
+        /// Gets the captured Node identifier.
+        /// </summary>
+        public string? NodeId { get; private set; }
+
+        /// <inheritdoc />
+        public string ProviderName => "openai";
+
+        /// <inheritdoc />
+        public Task<RotationResult> RotateAsync(RotationContext ctx, CancellationToken ct)
+        {
+            ArgumentNullException.ThrowIfNull(ctx);
+            ct.ThrowIfCancellationRequested();
+
+            var operationContext = operationContextAccessor.Current
+                ?? throw new InvalidOperationException("Expected an active operation context.");
+
+            Context = ctx;
+            TenantId = operationContext.TenantId;
+            NodeId = operationContext.GridContext.NodeId;
+            return Task.FromResult(RotationResult.Skipped(ProviderName, "captured"));
+        }
+    }
+}

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/RotationContextTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/RotationContextTests.cs
@@ -1,0 +1,29 @@
+using HoneyDrunk.Vault.Rotation.Abstractions;
+
+namespace HoneyDrunk.Vault.Rotation.Tests;
+
+/// <summary>
+/// Tests for rotation context invariants.
+/// </summary>
+public sealed class RotationContextTests
+{
+    /// <summary>
+    /// Verifies that rotation contexts require a populated correlation identifier.
+    /// </summary>
+    /// <param name="correlationId">The invalid correlation identifier.</param>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ConstructorRejectsMissingCorrelationId(string? correlationId)
+    {
+        var act = () => new RotationContext(
+            "openai",
+            "test-vault",
+            "test-secret",
+            DateTimeOffset.UtcNow,
+            correlationId!);
+
+        Assert.ThrowsAny<ArgumentException>(act);
+    }
+}

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/RotationContextTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/RotationContextTests.cs
@@ -26,4 +26,36 @@ public sealed class RotationContextTests
 
         Assert.ThrowsAny<ArgumentException>(act);
     }
+
+    /// <summary>
+    /// Verifies that immutable-copy initialization cannot bypass validated identity fields.
+    /// </summary>
+    /// <param name="fieldName">The field to mutate.</param>
+    /// <param name="invalidValue">The invalid value.</param>
+    [Theory]
+    [InlineData(nameof(RotationContext.ProviderName), null)]
+    [InlineData(nameof(RotationContext.ProviderName), "")]
+    [InlineData(nameof(RotationContext.TargetVaultName), "   ")]
+    [InlineData(nameof(RotationContext.SecretName), "")]
+    [InlineData(nameof(RotationContext.CorrelationId), "   ")]
+    public void WithExpressionRejectsMissingRequiredFields(string fieldName, string? invalidValue)
+    {
+        var context = new RotationContext(
+            "openai",
+            "test-vault",
+            "test-secret",
+            DateTimeOffset.UtcNow,
+            "test-correlation");
+
+        Action act = fieldName switch
+        {
+            nameof(RotationContext.ProviderName) => () => _ = context with { ProviderName = invalidValue! },
+            nameof(RotationContext.TargetVaultName) => () => _ = context with { TargetVaultName = invalidValue! },
+            nameof(RotationContext.SecretName) => () => _ = context with { SecretName = invalidValue! },
+            nameof(RotationContext.CorrelationId) => () => _ = context with { CorrelationId = invalidValue! },
+            _ => throw new InvalidOperationException($"Unknown field '{fieldName}'."),
+        };
+
+        Assert.ThrowsAny<ArgumentException>(act);
+    }
 }

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/RotatorRegistrationTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/RotatorRegistrationTests.cs
@@ -28,4 +28,44 @@ public sealed class RotatorRegistrationTests
 
         Assert.Equal(["openai", "resend", "twilio"], providerNames);
     }
+
+    /// <summary>
+    /// Verifies that every provider registration keeps the placeholder skipped behavior.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task ProviderStubsReturnSkippedPlaceholderResults()
+    {
+        var services = new ServiceCollection();
+        services.AddHoneyDrunkVaultRotators();
+
+        using var provider = services.BuildServiceProvider();
+        var rotators = provider.GetServices<IRotator>().OrderBy(rotator => rotator.ProviderName).ToArray();
+        var context = new RotationContext(
+            "test-provider",
+            "test-vault",
+            "test-secret",
+            DateTimeOffset.UtcNow,
+            "test-correlation");
+
+        var results = new List<RotationResult>();
+        foreach (var rotator in rotators)
+        {
+            results.Add(await rotator.RotateAsync(context with { ProviderName = rotator.ProviderName }, CancellationToken.None));
+        }
+
+        Assert.Collection(
+            results,
+            result => AssertPlaceholderResult(result, "openai", "OpenAI rotation is not implemented in the scaffold."),
+            result => AssertPlaceholderResult(result, "resend", "Resend rotation is not implemented in the scaffold."),
+            result => AssertPlaceholderResult(result, "twilio", "Twilio rotation is not implemented in the scaffold."));
+    }
+
+    private static void AssertPlaceholderResult(RotationResult result, string providerName, string message)
+    {
+        Assert.Equal(providerName, result.ProviderName);
+        Assert.Equal(RotationStatus.Skipped, result.Status);
+        Assert.Equal(message, result.Message);
+        Assert.NotNull(result.CompletedAtUtc);
+    }
 }


### PR DESCRIPTION
## Summary
- establish Kernel Grid/Operation context for the timer-triggered rotation scaffold before provider work starts
- require non-empty `RotationContext.CorrelationId` and flow Kernel correlation IDs into provider rotation calls
- consolidate OpenAI/Resend/Twilio placeholder behavior behind a shared `PlaceholderRotator` scaffold
- align runtime package dependencies to Kernel `0.7.0` and Vault `0.5.0` without bumping Vault.Rotation package versions because no prior repo tag/NuGet package exists

## Packet links
- `generated/issue-packets/active/kernel-adoption-alignment/07-vault-rotation-establish-timer-operation-context.md`
- `generated/issue-packets/active/standalone/2026-05-04-vault-rotation-consolidate-vault-rotation-placeholder-rotators.md`

## Validation
- `dotnet restore HoneyDrunk.Vault.Rotation.slnx --ignore-failed-sources`
- `dotnet build HoneyDrunk.Vault.Rotation.slnx -c Release --no-restore`
- `dotnet test HoneyDrunk.Vault.Rotation.slnx -c Release --no-build --verbosity minimal`
- `git diff --check`
- repo-wide scan for remaining placeholder rotator duplication / nullable correlation use

Closes #7
Closes #5
