### PR TITLE
test: backfill Vault.Rotation coverage gate

### DIFF
--- a/.github/coverage-baseline.json
+++ b/.github/coverage-baseline.json
@@ -1,0 +1,5 @@
+{
+  "totalLineCoverage": 78.0,
+  "commit": "pending-merge",
+  "measuredAtUtc": "2026-05-19T16:10:38Z"
+}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -7,19 +7,27 @@ on:
       - '**/*.cs'
       - '**/*.csproj'
       - '**/*.sln'
+      - '**/*.slnx'
       - '**/*.props'
       - '**/*.targets'
+      - '**/*.runsettings'
       - '**/.editorconfig'
       - '**/stylecop.json'
+      - '.github/workflows/**'
+  push:
+    branches: [ main ]
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
-  security-events: write
 
 jobs:
   pr-validation:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      security-events: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
     with:
       dotnet-version: '10.0.x'
@@ -29,7 +37,26 @@ jobs:
       project-path: 'HoneyDrunk.Vault.Rotation.slnx'
       enable-secret-scan: true
       enable-accessibility-check: false
+      patch-coverage-threshold: 75
+      absolute-coverage-floor: 70
       post-pr-summary: true
+      actions-ref: 'main'
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  coverage-baseline-ratchet:
+    name: Coverage Baseline Ratchet
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+      checks: write
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/coverage-baseline-ratchet.yml@main
+    with:
+      dotnet-version: '10.0.x'
+      configuration: 'Release'
+      runs-on: 'ubuntu-latest'
+      working-directory: '.'
+      project-path: 'HoneyDrunk.Vault.Rotation.slnx'
       actions-ref: 'main'
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -13,7 +13,7 @@ on:
       - '**/*.runsettings'
       - '**/.editorconfig'
       - '**/stylecop.json'
-      - '.github/workflows/**'
+      - '.github/**'
   push:
     branches: [ main ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ _TeamCity*
 
 # Coverlet is a free, cross platform Code Coverage Tool
 coverage*.json
+!**/.github/coverage-baseline.json
 coverage*.xml
 coverage*.info
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Internal
+
+- Backfilled test coverage above the Grid PR coverage gate floor and seeded the coverage baseline ratchet artifact.
+
 ## [0.1.0] - 2026-04-25
 
 ### Added

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByFile>**/Microsoft.Azure.Functions.Worker.Sdk.Generators/**/*.g.cs</ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/tests/HoneyDrunk.Vault.Rotation.Canary/HoneyDrunk.Vault.Rotation.Canary.csproj
+++ b/tests/HoneyDrunk.Vault.Rotation.Canary/HoneyDrunk.Vault.Rotation.Canary.csproj
@@ -2,9 +2,14 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <RunSettingsFilePath>../../coverlet.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/HoneyDrunk.Vault.Rotation.Tests.csproj
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/HoneyDrunk.Vault.Rotation.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <RunSettingsFilePath>../../coverlet.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/RotateThirdPartySecretsFunctionTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/RotateThirdPartySecretsFunctionTests.cs
@@ -21,22 +21,9 @@ public sealed class RotateThirdPartySecretsFunctionTests
     [Fact]
     public async Task RunCreatesKernelOperationContextForTimerExecution()
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services
-            .AddHoneyDrunkNode(options =>
-            {
-                options.NodeId = WellKnownNodes.Core.VaultRotation;
-                options.SectorId = Sectors.Core;
-                options.EnvironmentId = GridEnvironments.Development;
-                options.StudioId = "honeydrunk";
-                options.Version = "0.1.0";
-            })
-            .Services
+        using var provider = BuildProvider(services => services
             .AddSingleton<CapturingRotator>()
-            .AddSingleton<IRotator>(sp => sp.GetRequiredService<CapturingRotator>());
-
-        using var provider = services.BuildServiceProvider();
+            .AddSingleton<IRotator>(sp => sp.GetRequiredService<CapturingRotator>()));
         var function = new RotateThirdPartySecretsFunction(
             provider.GetRequiredService<IServiceScopeFactory>(),
             NullLogger<RotateThirdPartySecretsFunction>.Instance);
@@ -49,6 +36,60 @@ public sealed class RotateThirdPartySecretsFunctionTests
         Assert.Equal(TenantId.Internal, rotator.TenantId);
         Assert.Equal(WellKnownNodes.Core.VaultRotation.Value, rotator.NodeId);
         Assert.Null(provider.GetRequiredService<IOperationContextAccessor>().Current);
+    }
+
+    /// <summary>
+    /// Verifies that failed rotators fail the active operation and clear operation context.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task RunClearsOperationContextWhenRotatorFails()
+    {
+        using var provider = BuildProvider(services => services.AddSingleton<IRotator>(new ThrowingRotator()));
+        var function = new RotateThirdPartySecretsFunction(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<RotateThirdPartySecretsFunction>.Instance);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => function.Run(null!, CancellationToken.None));
+
+        Assert.Null(provider.GetRequiredService<IOperationContextAccessor>().Current);
+    }
+
+    /// <summary>
+    /// Verifies that cancellation from a rotator fails the operation and preserves cancellation semantics.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task RunClearsOperationContextWhenRotatorCancels()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        using var provider = BuildProvider(services => services.AddSingleton<IRotator>(new CancelingRotator(cancellationSource)));
+        var function = new RotateThirdPartySecretsFunction(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<RotateThirdPartySecretsFunction>.Instance);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => function.Run(null!, cancellationSource.Token));
+
+        Assert.True(cancellationSource.IsCancellationRequested);
+        Assert.Null(provider.GetRequiredService<IOperationContextAccessor>().Current);
+    }
+
+    private static ServiceProvider BuildProvider(Action<IServiceCollection> configureRotators)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services
+            .AddHoneyDrunkNode(options =>
+            {
+                options.NodeId = WellKnownNodes.Core.VaultRotation;
+                options.SectorId = Sectors.Core;
+                options.EnvironmentId = GridEnvironments.Development;
+                options.StudioId = "honeydrunk";
+                options.Version = "0.1.0";
+            });
+
+        configureRotators(services);
+        return services.BuildServiceProvider();
     }
 
     /// <summary>
@@ -88,6 +129,25 @@ public sealed class RotateThirdPartySecretsFunctionTests
             TenantId = operationContext.TenantId;
             NodeId = operationContext.GridContext.NodeId;
             return Task.FromResult(RotationResult.Skipped(ProviderName, "captured"));
+        }
+    }
+
+    private sealed class ThrowingRotator : IRotator
+    {
+        public string ProviderName => "throwing";
+
+        public Task<RotationResult> RotateAsync(RotationContext ctx, CancellationToken ct) =>
+            Task.FromException<RotationResult>(new InvalidOperationException("rotation failed"));
+    }
+
+    private sealed class CancelingRotator(CancellationTokenSource cancellationSource) : IRotator
+    {
+        public string ProviderName => "canceling";
+
+        public Task<RotationResult> RotateAsync(RotationContext ctx, CancellationToken ct)
+        {
+            cancellationSource.Cancel();
+            return Task.FromCanceled<RotationResult>(ct);
         }
     }
 }

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/RotationContextTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/RotationContextTests.cs
@@ -8,6 +8,34 @@ namespace HoneyDrunk.Vault.Rotation.Tests;
 public sealed class RotationContextTests
 {
     /// <summary>
+    /// Verifies that the constructor preserves all validated rotation request fields.
+    /// </summary>
+    [Fact]
+    public void ConstructorPreservesRotationRequestFields()
+    {
+        var requestedAt = new DateTimeOffset(2026, 5, 19, 12, 0, 0, TimeSpan.Zero);
+        var metadata = new Dictionary<string, string>
+        {
+            ["rotation-mode"] = "placeholder",
+        };
+
+        var context = new RotationContext(
+            "openai",
+            "target-vault",
+            "api-key",
+            requestedAt,
+            "correlation-123",
+            metadata);
+
+        Assert.Equal("openai", context.ProviderName);
+        Assert.Equal("target-vault", context.TargetVaultName);
+        Assert.Equal("api-key", context.SecretName);
+        Assert.Equal(requestedAt, context.RequestedAtUtc);
+        Assert.Equal("correlation-123", context.CorrelationId);
+        Assert.Same(metadata, context.Metadata);
+    }
+
+    /// <summary>
     /// Verifies that rotation contexts require a populated correlation identifier.
     /// </summary>
     /// <param name="correlationId">The invalid correlation identifier.</param>

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/RotationContextTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/RotationContextTests.cs
@@ -32,7 +32,8 @@ public sealed class RotationContextTests
         Assert.Equal("api-key", context.SecretName);
         Assert.Equal(requestedAt, context.RequestedAtUtc);
         Assert.Equal("correlation-123", context.CorrelationId);
-        Assert.Same(metadata, context.Metadata);
+        Assert.NotNull(context.Metadata);
+        Assert.Equal("placeholder", context.Metadata["rotation-mode"]);
     }
 
     /// <summary>

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/RotationResultTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/RotationResultTests.cs
@@ -1,0 +1,29 @@
+using HoneyDrunk.Vault.Rotation.Abstractions;
+
+namespace HoneyDrunk.Vault.Rotation.Tests;
+
+/// <summary>
+/// Tests for rotation result factory behavior.
+/// </summary>
+public sealed class RotationResultTests
+{
+    /// <summary>
+    /// Verifies that skipped results carry provider, status, message, and completion time.
+    /// </summary>
+    [Fact]
+    public void SkippedCreatesOperationalResult()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var result = RotationResult.Skipped("openai", "not implemented yet");
+
+        Assert.Equal("openai", result.ProviderName);
+        Assert.Equal(RotationStatus.Skipped, result.Status);
+        Assert.Null(result.SecretName);
+        Assert.Null(result.NewVersion);
+        Assert.Equal("not implemented yet", result.Message);
+        Assert.NotNull(result.CompletedAtUtc);
+        Assert.True(result.CompletedAtUtc >= before);
+        Assert.True(result.CompletedAtUtc <= DateTimeOffset.UtcNow);
+    }
+}


### PR DESCRIPTION
## Summary
- Backfills Vault.Rotation unit coverage across rotation function failure/cancellation paths, rotation context field preservation, and skipped-result factory behavior.
- Adds a repo-level coverlet runsettings file so generated Azure Functions Worker SDK files are excluded from the coverage denominator instead of counting scaffolded generated code against product coverage.
- Adds coverlet collector wiring for the canary project and seeds `.github/coverage-baseline.json` at the locally measured total line coverage.
- Splits PR validation from the default-branch coverage ratchet: PRs run read-only `pr-core`; pushes to `main` run the write-scoped ratchet workflow.
- Adds the repo-level Unreleased/Internal changelog note.

## Coverage
- Initial measured total line coverage: **55.4%** (`133/240` lines) before generated Functions Worker SDK exclusion/backfill.
- Final measured total line coverage: **78.0%** (`146/187` lines) with `-assemblyfilters:+*;-*.Tests`.
- Final branch coverage: **33.3%**.

## Validation
- `dotnet test HoneyDrunk.Vault.Rotation.slnx --collect:"XPlat Code Coverage" --results-directory coverage-raw-final` + `reportgenerator -assemblyfilters:"+*;-*.Tests"` — **78.0%** total line coverage.
- `dotnet test HoneyDrunk.Vault.Rotation.slnx --no-restore` — **17 passed**.
- `dotnet format HoneyDrunk.Vault.Rotation.slnx --verify-no-changes --no-restore` — passed.
- Workflow YAML parse — passed.
- `git diff --check` — passed.

Fixes #6
