### PR TITLE
test: align Vault.Rotation with ADR-0047 test stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Internal
 
+- Adopted HoneyDrunk.Standards.Tests 0.2.9 for Vault.Rotation test and canary projects, removed direct test SDK / runner / coverlet references, and refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 alignment.
 - Backfilled test coverage above the Grid PR coverage gate floor and seeded the coverage baseline ratchet artifact.
 
 ## [0.1.0] - 2026-04-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Internal
 
-- Adopted HoneyDrunk.Standards.Tests 0.2.9 for Vault.Rotation test and canary projects, removed direct test SDK / runner / coverlet references, and refreshed HoneyDrunk.Standards to 0.2.9 for ADR-0047 alignment.
+- Adopted HoneyDrunk.Standards.Tests 0.2.9 for Vault.Rotation test and canary projects, removed direct test SDK / runner / coverlet references, refreshed HoneyDrunk.Standards to 0.2.9, and covered runtime bootstrap configuration for ADR-0047 alignment.
 - Backfilled test coverage above the Grid PR coverage gate floor and seeded the coverage baseline ratchet artifact.
 
 ## [0.1.0] - 2026-04-25

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.7">
+    <PackageReference Include="HoneyDrunk.Standards" Version="0.2.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -4,7 +4,7 @@
     <DataCollectors>
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
-          <ExcludeByFile>**/Microsoft.Azure.Functions.Worker.Sdk.Generators/**/*.g.cs</ExcludeByFile>
+          <ExcludeByFile>**/Microsoft.Azure.Functions.Worker.Sdk.Generators/**/*.g.cs,**/Program.cs</ExcludeByFile>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/src/HoneyDrunk.Vault.Rotation/HoneyDrunk.Vault.Rotation.csproj
+++ b/src/HoneyDrunk.Vault.Rotation/HoneyDrunk.Vault.Rotation.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="HoneyDrunk.Vault.Rotation.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="HoneyDrunk.Kernel" Version="0.7.0" />
     <PackageReference Include="HoneyDrunk.Vault" Version="0.5.0" />

--- a/src/HoneyDrunk.Vault.Rotation/Program.cs
+++ b/src/HoneyDrunk.Vault.Rotation/Program.cs
@@ -1,64 +1,12 @@
-using HoneyDrunk.Kernel.Abstractions;
-using HoneyDrunk.Kernel.Abstractions.Identity;
-using HoneyDrunk.Kernel.Hosting;
-using HoneyDrunk.Vault.Extensions;
-using HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
-using HoneyDrunk.Vault.Rotation.Providers.DependencyInjection;
+using HoneyDrunk.Vault.Rotation;
 using Microsoft.Azure.Functions.Worker.Builder;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using GridEnvironments = HoneyDrunk.Kernel.Abstractions.Environments;
-
-const string KeyVaultUriSetting = "AZURE_KEYVAULT_URI";
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
-var honeyDrunkBuilder = builder.Services
-    .AddHoneyDrunkNode(options =>
-    {
-        options.NodeId = ResolveNodeId(builder.Configuration);
-        options.SectorId = Sectors.Core;
-        options.EnvironmentId = ResolveEnvironment(builder.Configuration);
-        options.Version = typeof(Program).Assembly.GetName().Version?.ToString() ?? "0.1.0";
-        options.StudioId = builder.Configuration["Grid:StudioId"] ?? "honeydrunk";
-        options.Tags["service"] = "vaultrot";
-        options.Tags["adr"] = "ADR-0006";
-    })
-    .AddVault();
-
-if (Uri.TryCreate(builder.Configuration[KeyVaultUriSetting], UriKind.Absolute, out var vaultUri))
-{
-    honeyDrunkBuilder.Services.AddVaultWithAzureKeyVault(options =>
-    {
-        options.VaultUri = vaultUri;
-        options.UseManagedIdentity = true;
-    });
-}
-
-honeyDrunkBuilder.Services
-    .AddHoneyDrunkVaultRotators();
+VaultRotationBootstrapper.Configure(
+    builder.Services,
+    builder.Configuration,
+    typeof(Program).Assembly.GetName().Version?.ToString() ?? "0.1.0");
 
 builder.Build().Run();
-
-static NodeId ResolveNodeId(IConfiguration configuration)
-{
-    var configured =
-        configuration["HONEYDRUNK_NODE_ID"]
-        ?? configuration["Grid:NodeId"];
-
-    return string.IsNullOrWhiteSpace(configured)
-        ? WellKnownNodes.Core.VaultRotation
-        : new NodeId(configured);
-}
-
-static EnvironmentId ResolveEnvironment(IConfiguration configuration)
-{
-    var configured =
-        configuration["Grid:Environment"]
-        ?? configuration["DOTNET_ENVIRONMENT"]
-        ?? configuration["AZURE_FUNCTIONS_ENVIRONMENT"];
-
-    return string.IsNullOrWhiteSpace(configured)
-        ? GridEnvironments.Development
-        : new EnvironmentId(configured.ToLowerInvariant());
-}

--- a/src/HoneyDrunk.Vault.Rotation/VaultRotationBootstrapper.cs
+++ b/src/HoneyDrunk.Vault.Rotation/VaultRotationBootstrapper.cs
@@ -1,0 +1,67 @@
+using HoneyDrunk.Kernel.Abstractions;
+using HoneyDrunk.Kernel.Abstractions.Identity;
+using HoneyDrunk.Kernel.Hosting;
+using HoneyDrunk.Vault.Extensions;
+using HoneyDrunk.Vault.Providers.AzureKeyVault.Extensions;
+using HoneyDrunk.Vault.Rotation.Providers.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using GridEnvironments = HoneyDrunk.Kernel.Abstractions.Environments;
+
+namespace HoneyDrunk.Vault.Rotation;
+
+internal static class VaultRotationBootstrapper
+{
+    private const string KeyVaultUriSetting = "AZURE_KEYVAULT_URI";
+
+    public static void Configure(IServiceCollection services, IConfiguration configuration, string version)
+    {
+        var honeyDrunkBuilder = services
+            .AddHoneyDrunkNode(options =>
+            {
+                options.NodeId = ResolveNodeId(configuration);
+                options.SectorId = Sectors.Core;
+                options.EnvironmentId = ResolveEnvironment(configuration);
+                options.Version = version;
+                options.StudioId = configuration["Grid:StudioId"] ?? "honeydrunk";
+                options.Tags["service"] = "vaultrot";
+                options.Tags["adr"] = "ADR-0006";
+            })
+            .AddVault();
+
+        if (Uri.TryCreate(configuration[KeyVaultUriSetting], UriKind.Absolute, out var vaultUri))
+        {
+            honeyDrunkBuilder.Services.AddVaultWithAzureKeyVault(options =>
+            {
+                options.VaultUri = vaultUri;
+                options.UseManagedIdentity = true;
+            });
+        }
+
+        honeyDrunkBuilder.Services
+            .AddHoneyDrunkVaultRotators();
+    }
+
+    internal static NodeId ResolveNodeId(IConfiguration configuration)
+    {
+        var configured =
+            configuration["HONEYDRUNK_NODE_ID"]
+            ?? configuration["Grid:NodeId"];
+
+        return string.IsNullOrWhiteSpace(configured)
+            ? WellKnownNodes.Core.VaultRotation
+            : new NodeId(configured);
+    }
+
+    internal static EnvironmentId ResolveEnvironment(IConfiguration configuration)
+    {
+        var configured =
+            configuration["Grid:Environment"]
+            ?? configuration["DOTNET_ENVIRONMENT"]
+            ?? configuration["AZURE_FUNCTIONS_ENVIRONMENT"];
+
+        return string.IsNullOrWhiteSpace(configured)
+            ? GridEnvironments.Development
+            : new EnvironmentId(configured.ToLowerInvariant());
+    }
+}

--- a/tests/HoneyDrunk.Vault.Rotation.Canary/HoneyDrunk.Vault.Rotation.Canary.csproj
+++ b/tests/HoneyDrunk.Vault.Rotation.Canary/HoneyDrunk.Vault.Rotation.Canary.csproj
@@ -6,16 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="HoneyDrunk.Standards.Tests" Version="0.2.9" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/HoneyDrunk.Vault.Rotation.Tests.csproj
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/HoneyDrunk.Vault.Rotation.Tests.csproj
@@ -6,17 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="HoneyDrunk.Standards.Tests" Version="0.2.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/VaultRotationBootstrapperTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/VaultRotationBootstrapperTests.cs
@@ -1,0 +1,116 @@
+using HoneyDrunk.Kernel.Abstractions;
+using HoneyDrunk.Kernel.Abstractions.Identity;
+using HoneyDrunk.Vault.Rotation.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using GridEnvironments = HoneyDrunk.Kernel.Abstractions.Environments;
+
+namespace HoneyDrunk.Vault.Rotation.Tests;
+
+/// <summary>
+/// Tests for runtime bootstrap configuration.
+/// </summary>
+public sealed class VaultRotationBootstrapperTests
+{
+    /// <summary>
+    /// Verifies that runtime bootstrap wires Kernel, Vault, and provider rotators.
+    /// </summary>
+    [Fact]
+    public void ConfigureRegistersRuntimeServicesAndRotators()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Grid:StudioId"] = "studio-test",
+            ["Grid:NodeId"] = "custom-vaultrot",
+            ["Grid:Environment"] = "Staging",
+        });
+
+        VaultRotationBootstrapper.Configure(services, configuration, "0.1.0-test");
+
+        using var provider = services.BuildServiceProvider();
+        var rotators = provider.GetServices<IRotator>().Select(rotator => rotator.ProviderName).Order().ToArray();
+
+        Assert.Equal(["openai", "resend", "twilio"], rotators);
+    }
+
+    /// <summary>
+    /// Verifies that runtime bootstrap wires Azure Key Vault services when a vault URI is configured.
+    /// </summary>
+    [Fact]
+    public void ConfigureRegistersAzureKeyVaultWhenVaultUriIsConfigured()
+    {
+        var services = new ServiceCollection();
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["AZURE_KEYVAULT_URI"] = "https://vaultrot-test.vault.azure.net/",
+        });
+
+        VaultRotationBootstrapper.Configure(services, configuration, "0.1.0-test");
+
+        using var provider = services.BuildServiceProvider();
+        var rotators = provider.GetServices<IRotator>().Select(rotator => rotator.ProviderName).Order().ToArray();
+
+        Assert.Equal(["openai", "resend", "twilio"], rotators);
+    }
+
+    /// <summary>
+    /// Verifies NodeId resolution precedence and defaults.
+    /// </summary>
+    /// <param name="environmentNodeId">The environment variable node identifier.</param>
+    /// <param name="gridNodeId">The Grid configuration node identifier.</param>
+    /// <param name="expected">The expected resolved node identifier, or null for the default.</param>
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("env-node", "grid-node", "env-node")]
+    [InlineData(null, "grid-node", "grid-node")]
+    [InlineData("   ", null, null)]
+    public void ResolveNodeIdUsesEnvironmentThenGridThenDefault(string? environmentNodeId, string? gridNodeId, string? expected)
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["HONEYDRUNK_NODE_ID"] = environmentNodeId,
+            ["Grid:NodeId"] = gridNodeId,
+        });
+
+        var nodeId = VaultRotationBootstrapper.ResolveNodeId(configuration);
+
+        Assert.Equal(expected is null ? WellKnownNodes.Core.VaultRotation : new NodeId(expected), nodeId);
+    }
+
+    /// <summary>
+    /// Verifies environment resolution precedence, normalization, and defaults.
+    /// </summary>
+    /// <param name="gridEnvironment">The Grid environment setting.</param>
+    /// <param name="dotnetEnvironment">The DOTNET_ENVIRONMENT setting.</param>
+    /// <param name="functionsEnvironment">The Azure Functions environment setting.</param>
+    /// <param name="expected">The expected resolved environment, or null for the default.</param>
+    [Theory]
+    [InlineData(null, null, null, null)]
+    [InlineData("Production", "Staging", "Development", "production")]
+    [InlineData(null, "Staging", "Development", "staging")]
+    [InlineData(null, null, "Production", "production")]
+    [InlineData("   ", null, null, null)]
+    public void ResolveEnvironmentUsesGridThenDotnetThenFunctionsThenDefault(
+        string? gridEnvironment,
+        string? dotnetEnvironment,
+        string? functionsEnvironment,
+        string? expected)
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Grid:Environment"] = gridEnvironment,
+            ["DOTNET_ENVIRONMENT"] = dotnetEnvironment,
+            ["AZURE_FUNCTIONS_ENVIRONMENT"] = functionsEnvironment,
+        });
+
+        var environmentId = VaultRotationBootstrapper.ResolveEnvironment(configuration);
+
+        Assert.Equal(expected is null ? GridEnvironments.Development : new EnvironmentId(expected), environmentId);
+    }
+
+    private static IConfiguration BuildConfiguration(IReadOnlyDictionary<string, string?> values) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+}


### PR DESCRIPTION
## Summary

- adopt `HoneyDrunk.Standards.Tests` 0.2.9 in Vault.Rotation test and canary projects
- remove direct test SDK / runner / coverlet references now supplied by the shared test-stack package
- refresh `HoneyDrunk.Standards` from 0.2.7 to 0.2.9 via `Directory.Build.props`
- factor runtime bootstrap configuration for direct test coverage and keep the coverage gate at/above baseline after the shared test-stack collector runs canary coverage
- document the ADR-0047 cleanup in the repo changelog

## Validation

- `git diff --check`
- `dotnet restore HoneyDrunk.Vault.Rotation.slnx --source https://api.nuget.org/v3/index.json`
- `dotnet test HoneyDrunk.Vault.Rotation.slnx -c Release --no-restore --collect "XPlat Code Coverage" --results-directory TestResults`
  - `HoneyDrunk.Vault.Rotation.Canary`: 1 passed
  - `HoneyDrunk.Vault.Rotation.Tests`: 27 passed
  - local merged coverage: 78.5%

## ADR / Issues

Contributes to HoneyDrunk.Architecture#188 and HoneyDrunk.Architecture#189.