### PR TITLE
ci: enable Grid Review requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+-
+
+## Validation
+
+-
+
+## Authorship
+
+Authorship: <!-- human | agent-claude-code | agent-copilot | agent-codex | mixed -->
+
+## Notes
+
+-

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,26 @@
+name: Grid Review Request
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  request-grid-review:
+    # Secret-bearing workflow. This intentionally runs in pull_request_target
+    # context and delegates to HoneyDrunk.Actions without checking out or
+    # executing PR-head code before signing the OpenClaw webhook request.
+    uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/job-review-request.yml@main
+    with:
+      openclaw-webhook-url: ${{ vars.OPENCLAW_GRID_REVIEW_WEBHOOK_URL || '' }}
+      review-config-path: .honeydrunk-review.yaml
+      upload-fallback-artifact: true
+      post-fallback-comment: false
+      artifact-name: grid-review-request
+    secrets:
+      openclaw-webhook-secret: ${{ secrets.OPENCLAW_GRID_REVIEW_WEBHOOK_SECRET }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -9,8 +9,13 @@ permissions:
   pull-requests: read
   issues: write
 
+concurrency:
+  group: grid-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   request-grid-review:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     # Secret-bearing workflow. This intentionally runs in pull_request_target
     # context and delegates to HoneyDrunk.Actions without checking out or
     # executing PR-head code before signing the OpenClaw webhook request.

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -26,7 +26,8 @@ jobs:
     permissions:
       contents: read
       checks: write
-      pull-requests: write
+      pull-requests: write
+      issues: write
       security-events: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/pr-core.yml@main
     with:

--- a/.honeydrunk-review.yaml
+++ b/.honeydrunk-review.yaml
@@ -1,0 +1,8 @@
+enabled: true
+runner: openclaw-codex
+severity_floor: Suggest
+skip_paths:
+  - "**/*.Designer.cs"
+  - "**/*.g.cs"
+  - "**/generated/**"
+cost_cap_per_pr_usd: 0.00

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Enabled ADR-0044 Grid Review request workflow and repo-local OpenClaw/Codex review configuration.
+
 ### Internal
 
 - Adopted HoneyDrunk.Standards.Tests 0.2.9 for Vault.Rotation test and canary projects, removed direct test SDK / runner / coverlet references, refreshed HoneyDrunk.Standards to 0.2.9, and covered runtime bootstrap configuration for ADR-0047 alignment.


### PR DESCRIPTION
## Summary
- enable ADR-0044 Grid Review request workflow for this repo
- add repo-local HoneyDrunk review config consumed by the reusable workflow
- add ADR-0044 PR authorship template/changelog hygiene

## Validation
- python C:\Users\tatte\.openclaw\workspace\validate-yaml.py .github\workflows\pr-review.yml .honeydrunk-review.yaml
- git diff --check

Packet: ADR-0044 rollout
Authorship: agent-codex