### PR TITLE
ci: grant publish security events permission

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ permissions:
   contents: write
   packages: write
   id-token: write
+  security-events: write
 
 jobs:
   prepare:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,16 +11,13 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
-  security-events: write
+permissions: {}
 
 jobs:
   prepare:
     name: Prepare Release
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       version: ${{ steps.version.outputs.version }}
       version-tag: ${{ steps.version.outputs.version-tag }}
@@ -43,6 +40,11 @@ jobs:
   release:
     name: Build, Test, and Publish App Artifact
     needs: prepare
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      security-events: write
     uses: HoneyDrunkStudios/HoneyDrunk.Actions/.github/workflows/release.yml@main
     with:
       dotnet-version: '10.0.x'

--- a/tests/HoneyDrunk.Vault.Rotation.Canary/HoneyDrunk.Vault.Rotation.Canary.csproj
+++ b/tests/HoneyDrunk.Vault.Rotation.Canary/HoneyDrunk.Vault.Rotation.Canary.csproj
@@ -10,10 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\HoneyDrunk.Vault.Rotation.Abstractions\HoneyDrunk.Vault.Rotation.Abstractions.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/tests/HoneyDrunk.Vault.Rotation.Tests/GeneratedFunctionMetadataProviderTests.cs
+++ b/tests/HoneyDrunk.Vault.Rotation.Tests/GeneratedFunctionMetadataProviderTests.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Reflection;
+
+namespace HoneyDrunk.Vault.Rotation.Tests;
+
+/// <summary>
+/// Tests for Azure Functions worker generated metadata.
+/// </summary>
+public sealed class GeneratedFunctionMetadataProviderTests
+{
+    /// <summary>
+    /// Verifies that generated worker metadata includes the rotation timer function.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous test operation.</returns>
+    [Fact]
+    public async Task GetFunctionMetadataAsyncIncludesRotationFunction()
+    {
+        var providerType = typeof(RotateThirdPartySecretsFunction).Assembly.GetType(
+            "HoneyDrunk.Vault.Rotation.GeneratedFunctionMetadataProvider",
+            throwOnError: true)!;
+        var provider = Activator.CreateInstance(providerType)!;
+        var method = providerType.GetMethod("GetFunctionMetadataAsync", BindingFlags.Instance | BindingFlags.Public)!;
+
+        var task = (Task)method.Invoke(provider, [AppContext.BaseDirectory])!;
+        await task;
+
+        var result = (IEnumerable)task.GetType().GetProperty("Result")!.GetValue(task)!;
+        var names = result
+            .Cast<object>()
+            .Select(metadata => metadata.GetType().GetProperty("Name")!.GetValue(metadata))
+            .OfType<string>()
+            .ToArray();
+
+        Assert.Contains("RotateThirdPartySecretsFunction", names);
+    }
+}


### PR DESCRIPTION
## Summary

- Grants `security-events: write` only to the reusable publish job, with empty workflow/default and prepare-job permissions for least privilege.
- Removes the placeholder canary project's unused production project reference so it does not emit a zero-coverage artifact.
- Adds coverage for the generated Azure Functions metadata provider so the shared PR workflow clears the existing `78.0%` coverage baseline without lowering it.

Out-of-band reason: Follow-up from the ADR-0012 caller-permissions audit; no separate per-repo issue packet was filed before this small caller fix.

## Validation

- `dotnet test HoneyDrunk.Vault.Rotation.slnx -c Release --logger trx --results-directory "TestResults" --collect "XPlat Code Coverage" --settings "TestResults/coverlet.shared.runsettings"`

## Authorship

Authorship: agent-codex

## Notes

- Audit source: HoneyDrunk.Architecture `infrastructure/caller-permissions-audit.md` from ADR-0012 packet 08.
- The coverage baseline remains at `78.0%`; the added metadata-provider test raises the shared-action collector result above the baseline instead of weakening the ratchet.