### PR TITLE
ci: move workflow actions to Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -54,7 +54,7 @@ jobs:
             --no-build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: function-app
           path: ./publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
       contents: write
     steps:
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.prepare.outputs.version-tag }}
           name: HoneyDrunk.Vault.Rotation ${{ needs.prepare.outputs.version-tag }}


### PR DESCRIPTION
## Summary
- Updates workflow action pins from Node 20-backed majors to Node 24-compatible majors.
- Keeps the change limited to GitHub Actions workflow maintenance.

Authorship: agent-codex

Packet: N/A
Out-of-band reason: Direct maintenance request to eliminate GitHub Actions Node 20 deprecation warnings across HoneyDrunk workflows.

## Verification
- GitHub action metadata audit: all edited JavaScript action refs resolve to 
ode24.
- git diff --check

Size justification: N/A

